### PR TITLE
Authbackendhack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
+build
 *.pyc
 __pycache__
 .coverage

--- a/auth_backend/backends.py
+++ b/auth_backend/backends.py
@@ -6,7 +6,9 @@ from .models import KagisoUser
 
 class KagisoBackend(ModelBackend):
 
-    def authenticate(self, email, password, username=None, **kwargs):
+    # HACK: username is actually email, but Django passes in keyword args
+    # and expects username to exist
+    def authenticate(self, username, password, **kwargs):
         # Django calls our backend with username='xyz', password='abc'
         # e.g. credentials = {'username': 'Fred', 'password': 'open'}
         # authenticate(**credentials), even though we set USERNAME_FIELD to
@@ -14,9 +16,7 @@ class KagisoBackend(ModelBackend):
         # So we have to hack around it:
         # https://github.com/django/django/blob/master/django/contrib/auth/__init__.py#L74
 
-        if username:
-            email = username
-
+        email = username
         user = KagisoUser.objects.filter(email=email).first()
 
         if not user:

--- a/auth_backend/backends.py
+++ b/auth_backend/backends.py
@@ -6,7 +6,17 @@ from .models import KagisoUser
 
 class KagisoBackend(ModelBackend):
 
-    def authenticate(self, email, password, **kwargs):
+    def authenticate(self, email, password, username=None, **kwargs):
+        # Django calls our backend with username='xyz', password='abc'
+        # e.g. credentials = {'username': 'Fred', 'password': 'open'}
+        # authenticate(**credentials), even though we set USERNAME_FIELD to
+        # 'email' in models.py.
+        # So we have to hack around it:
+        # https://github.com/django/django/blob/master/django/contrib/auth/__init__.py#L74
+
+        if username:
+            email = username
+
         user = KagisoUser.objects.filter(email=email).first()
 
         if not user:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = --reuse-db
 norecursedirs =
+    build
     venv
     tests/integration


### PR DESCRIPTION
Django calls our backend with username='xyz', password='abc'
e.g. credentials = {'username': 'Fred', 'password': 'open'}
,authenticate(**credentials), even though we set USERNAME_FIELD to
'email' in models.py.
 we have to hack around it:
https://github.com/django/django/blob/master/django/contrib/auth/__init__.py#L74
