### PR TITLE
Allauth support

### DIFF
--- a/auth_backend/backends.py
+++ b/auth_backend/backends.py
@@ -6,17 +6,15 @@ from .models import KagisoUser
 
 class KagisoBackend(ModelBackend):
 
-    # HACK: username is actually email, but Django passes in keyword args
-    # and expects username to exist
-    def authenticate(self, username, password, **kwargs):
-        # Django calls our backend with username='xyz', password='abc'
-        # e.g. credentials = {'username': 'Fred', 'password': 'open'}
-        # authenticate(**credentials), even though we set USERNAME_FIELD to
-        # 'email' in models.py.
-        # So we have to hack around it:
-        # https://github.com/django/django/blob/master/django/contrib/auth/__init__.py#L74
-
-        email = username
+    # Django calls our backend with username='xyz', password='abc'
+    # e.g. credentials = {'username': 'Fred', 'password': 'open'}
+    # authenticate(**credentials), even though we set USERNAME_FIELD to
+    # 'email' in models.py.
+    #
+    # Django AllAuth does this:
+    #  credentials = {'email': 'test@kagiso.io, 'password': 'open'}
+    def authenticate(self, email=None, username=None, password=None, **kwargs):
+        email = username if not email else email
         user = KagisoUser.objects.filter(email=email).first()
 
         if not user:

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='0.2.0',
+    version='0.2.1',
     author='Kagiso Media',
     author_email='development@kagiso.io',
+    description='Kagiso Django AuthBackend',
     url='https://github.com/Kagiso-Future-Media/django_auth',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
django allauth passes the email address correctly, whereas django passes it as username, ignoring config directives, so have to support both scenarios