### PR TITLE
Multi-tenancy support and sign in sync

### DIFF
--- a/auth_backend/auth_api_client.py
+++ b/auth_backend/auth_api_client.py
@@ -48,7 +48,7 @@ class AuthApiClient:
 
         logger.debug('method={0}'.format(method))
         logger.debug('url={0}'.format(url))
-        logger.debug('headers={0}'.format(self.AUTH_HEADERS))
+        logger.debug('headers={0}'.format(auth_headers))
         logger.debug('payload={0}'.format(payload))
         logger.debug('json={0}'.format(json.dumps(payload)))
 

--- a/auth_backend/auth_api_client.py
+++ b/auth_backend/auth_api_client.py
@@ -6,46 +6,57 @@ import requests
 from . import settings
 from .exceptions import CASNetworkError, CASTimeout
 
+
 logger = logging.getLogger('django')
 
-AUTH_HEADERS = {
-    'AUTHORIZATION': 'Token {0}'.format(settings.CAS_TOKEN),
-    'SOURCE-ID': settings.CAS_SOURCE_ID,
-}
-BASE_URL = settings.CAS_BASE_URL
-TIMEOUT_IN_SECONDS = 3
 
+class AuthApiClient:
 
-def call(endpoint, method='GET', payload=None):
-    url = '{base_url}/{endpoint}/.json'.format(
-        base_url=BASE_URL,
-        endpoint=endpoint
-    )
+    BASE_URL = settings.CAS_BASE_URL
+    TIMEOUT_IN_SECONDS = 3
 
-    try:
-        response = requests.request(
-            method,
-            url,
-            headers=AUTH_HEADERS,
-            json=payload,
-            timeout=TIMEOUT_IN_SECONDS
+    def __init__(self, cas_credentials=None):
+        if cas_credentials is None:
+            self._cas_token = settings.CAS_TOKEN
+            self._cas_source_id = settings.CAS_SOURCE_ID
+        else:
+            self._cas_token = cas_credentials['cas_token']
+            self._cas_source_id = cas_credentials['cas_source_id']
+
+    def call(self, endpoint, method='GET', payload=None):
+        auth_headers = {
+            'AUTHORIZATION': 'Token {0}'.format(self._cas_token),
+            'SOURCE-ID': self._cas_source_id,
+        }
+        url = '{base_url}/{endpoint}/.json'.format(
+            base_url=self.BASE_URL,
+            endpoint=endpoint
         )
-    except requests.exceptions.ConnectionError as e:
-        raise CASNetworkError from e
-    except requests.exceptions.Timeout as e:
-        raise CASTimeout from e
 
-    logger.debug('method={0}'.format(method))
-    logger.debug('url={0}'.format(url))
-    logger.debug('headers={0}'.format(AUTH_HEADERS))
-    logger.debug('payload={0}'.format(payload))
-    logger.debug('json={0}'.format(json.dumps(payload)))
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=auth_headers,
+                json=payload,
+                timeout=self.TIMEOUT_IN_SECONDS
+            )
+        except requests.exceptions.ConnectionError as e:
+            raise CASNetworkError from e
+        except requests.exceptions.Timeout as e:
+            raise CASTimeout from e
 
-    json_data = {}
-    try:
-        json_data = response.json()
-    except ValueError:
-        # Requests chokes on empty body
-        pass
+        logger.debug('method={0}'.format(method))
+        logger.debug('url={0}'.format(url))
+        logger.debug('headers={0}'.format(self.AUTH_HEADERS))
+        logger.debug('payload={0}'.format(payload))
+        logger.debug('json={0}'.format(json.dumps(payload)))
 
-    return response.status_code, json_data
+        json_data = {}
+        try:
+            json_data = response.json()
+        except ValueError:
+            # Requests chokes on empty body
+            pass
+
+        return response.status_code, json_data

--- a/auth_backend/backends.py
+++ b/auth_backend/backends.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.backends import ModelBackend
 from django.db.models.signals import pre_save
 
-from . import auth_api_client
+from .auth_api_client import AuthApiClient
 from .exceptions import CASUnexpectedStatusCode
 from .models import KagisoUser, save_user_to_cas
 
@@ -16,6 +16,8 @@ class KagisoBackend(ModelBackend):
     # Django AllAuth does this:
     #  credentials = {'email': 'test@kagiso.io, 'password': 'open'}
     def authenticate(self, email=None, username=None, password=None, **kwargs):
+        cas_credentials = kwargs.get('cas_credentials')
+
         email = username if not email else email
         existing_user = KagisoUser.objects.filter(email=email).first()
 
@@ -32,18 +34,22 @@ class KagisoBackend(ModelBackend):
         if strategy:
             payload['strategy'] = strategy
 
+        auth_api_client = AuthApiClient(cas_credentials)
         status, data = auth_api_client.call('sessions', 'POST', payload)
 
         if status not in (200, 404,):
             raise CASUnexpectedStatusCode(status, data)
 
         if status == 200:
-            if not existing_user:
+            if existing_user:
+                existing_user.cas_credentials = cas_credentials
+            else:
                 try:
                     # Do not on save sync to CAS, as we just got the user's
                     # data from CAS, and nothing has changed in the interim
                     pre_save.disconnect(save_user_to_cas, sender=KagisoUser)
-                    existing_user = KagisoUser()
+                    existing_user = KagisoUser(cas_credentials)
+                    existing_user.set_password(password)
                     existing_user.create_from_cas_data(data)
                     existing_user.save()
                 finally:

--- a/auth_backend/backends.py
+++ b/auth_backend/backends.py
@@ -50,7 +50,7 @@ class KagisoBackend(ModelBackend):
                     pre_save.disconnect(save_user_to_cas, sender=KagisoUser)
                     existing_user = KagisoUser(cas_credentials)
                     existing_user.set_password(password)
-                    existing_user.create_from_cas_data(data)
+                    existing_user.build_from_cas_data(data)
                     existing_user.save()
                 finally:
                     pre_save.connect(save_user_to_cas, sender=KagisoUser)

--- a/auth_backend/models.py
+++ b/auth_backend/models.py
@@ -138,11 +138,11 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
         if status == 200:
             self.email = data['email']
-            self.first_name = data['first_name']
-            self.last_name = data['last_name']
-            self.is_staff = data['is_staff']
-            self.is_superuser = data['is_superuser']
-            self.profile = data['profile']
+            self.first_name = data.get('first_name')
+            self.last_name = data.get('last_name')
+            self.is_staff = data.get('is_staff')
+            self.is_superuser = data.get('is_superuser')
+            self.profile = data.get('profile')
             self.modified = parser.parse(data['modified'])
         elif status == 404:
             # It is possible that a user exists locally but not on CAS

--- a/auth_backend/models.py
+++ b/auth_backend/models.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from jsonfield import JSONField
 
-from . import auth_api_client
+from .auth_api_client import AuthApiClient
 from .exceptions import CASUnexpectedStatusCode
 from .managers import AuthManager
 
@@ -29,6 +29,16 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
     raw_password = None
 
     objects = AuthManager()
+
+    def __init__(self, *args, **kwargs):
+        self.cas_credentials = kwargs.get('cas_credentials')
+        self._auth_api_client = AuthApiClient(self.cas_credentials)
+
+        if self.cas_credentials:
+            # Django crashes if non-model fields are passed to init
+            del kwargs['cas_credentials']
+
+        super().__init__(*args, **kwargs)
 
     def get_full_name(self):
         return self.email
@@ -53,7 +63,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
     def confirm_email(self, confirmation_token):
         payload = {'confirmation_token': confirmation_token}
         endpoint = 'users/{id}/confirm_email'.format(id=self.id)
-        status, data = auth_api_client.call(endpoint, 'POST', payload)
+        status, data = self._auth_api_client.call(endpoint, 'POST', payload)
 
         if not status == 200:
             raise CASUnexpectedStatusCode(status, data)
@@ -64,7 +74,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
     def generate_reset_password_token(self):
         endpoint = 'users/{id}/reset_password'.format(id=self.id)
-        status, data = auth_api_client.call(endpoint, 'GET')
+        status, data = self._auth_api_client.call(endpoint, 'GET')
 
         if not status == 200:
             raise CASUnexpectedStatusCode(status, data)
@@ -77,7 +87,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
             'password': password,
         }
         endpoint = 'users/{id}/reset_password'.format(id=self.id)
-        status, data = auth_api_client.call(endpoint, 'POST', payload)
+        status, data = self._auth_api_client.call(endpoint, 'POST', payload)
 
         if not status == 200:
             raise CASUnexpectedStatusCode(status, data)
@@ -86,7 +96,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
     def record_sign_out(self):
         endpoint = 'sessions/{id}'.format(id=self.id)
-        status, data = auth_api_client.call(endpoint, 'DELETE')
+        status, data = self._auth_api_client.call(endpoint, 'DELETE')
 
         if not status == 200:
             raise CASUnexpectedStatusCode(status, data)
@@ -116,7 +126,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
             'password': self.raw_password,
         }
 
-        status, data = auth_api_client.call('users', 'POST', payload)
+        status, data = self._auth_api_client.call('users', 'POST', payload)
 
         if status not in (201, 409):
             raise CASUnexpectedStatusCode(status, data)
@@ -135,7 +145,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
             'profile': self.profile,
         }
 
-        status, data = auth_api_client.call(
+        status, data = self._auth_api_client.call(
             'users/{id}'.format(id=self.id), 'PUT', payload)
 
         if status == 200:
@@ -160,7 +170,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
 @receiver(pre_delete, sender=KagisoUser)
 def delete_user_from_cas(sender, instance, *args, **kwargs):
-    status, data = auth_api_client.call(
+    status, data = instance._auth_api_client.call(
         'users/{id}'.format(id=instance.id), 'DELETE')
 
     # It is possible but unlikely that a user exists locally but not on CAS

--- a/auth_backend/models.py
+++ b/auth_backend/models.py
@@ -103,7 +103,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
         return True
 
-    def create_from_cas_data(self, data):
+    def build_from_cas_data(self, data):
         self.id = data['id']
         self.email = data['email']
         self.first_name = data.get('first_name', self.first_name)
@@ -133,7 +133,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
         # 409-Conflict means that the user already exists in CAS
         # Set the user's data to what CAS returns.
-        self.create_from_cas_data(data)
+        self.build_from_cas_data(data)
 
     def _update_user_in_cas(self):
         payload = {

--- a/auth_backend/models.py
+++ b/auth_backend/models.py
@@ -93,6 +93,18 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
         return True
 
+    def create_from_cas_data(self, data):
+        self.id = data['id']
+        self.email = data['email']
+        self.first_name = data.get('first_name', self.first_name)
+        self.last_name = data.get('last_name', self.last_name)
+        self.is_staff = data.get('is_staff', self.is_staff)
+        self.is_superuser = data.get('is_superuser', self.is_superuser)
+        self.profile = data.get('profile', self.profile)
+        self.confirmation_token = data.get('confirmation_token')
+        self.date_joined = parser.parse(data['created'])
+        self.modified = parser.parse(data['modified'])
+
     def _create_user_in_db_and_cas(self):
         payload = {
             'email': self.email,
@@ -111,17 +123,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
 
         # 409-Conflict means that the user already exists in CAS
         # Set the user's data to what CAS returns.
-        # CAS data takes precedence.
-        self.id = data['id']
-        self.email = data['email']
-        self.first_name = data.get('first_name', self.first_name)
-        self.last_name = data.get('last_name', self.last_name)
-        self.is_staff = data.get('is_staff', self.is_staff)
-        self.is_superuser = data.get('is_superuser', self.is_superuser)
-        self.profile = data.get('profile', self.profile)
-        self.confirmation_token = data.get('confirmation_token')
-        self.date_joined = parser.parse(data['created'])
-        self.modified = parser.parse(data['modified'])
+        self.create_from_cas_data(data)
 
     def _update_user_in_cas(self):
         payload = {

--- a/auth_backend/tests/unit/mocks.py
+++ b/auth_backend/tests/unit/mocks.py
@@ -105,16 +105,29 @@ def mock_out_post_reset_password(id, status=200):
     return url
 
 
-def mock_out_post_sessions(status):
+def mock_out_post_sessions(status=200, **kwargs):
     url = 'https://auth.kagiso.io/api/v1/sessions/.json'
+    data = {
+        'id': kwargs.get('id', 1),
+        'email': kwargs.get('email'),
+        'first_name': kwargs.get('first_name', ''),
+        'last_name': kwargs.get('last_name', ''),
+        'is_staff': kwargs.get('is_staff', False),
+        'is_superuser': kwargs.get('is_superuser', False),
+        'email_confirmed': None,
+        'profile': kwargs.get('profile'),
+        'created': '2015-04-21T08:18:30.368602Z',
+        'modified': '2015-04-21T08:18:30.374410Z'
+    }
 
     responses.add(
         responses.POST,
         url,
+        body=json.dumps(data),
         status=status
     )
 
-    return url
+    return url, data
 
 
 def mock_out_delete_sessions(id, status=200):

--- a/auth_backend/tests/unit/test_auth_api_client.py
+++ b/auth_backend/tests/unit/test_auth_api_client.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 import pytest
 import requests
 
-from ... import auth_api_client
+from ...auth_api_client import AuthApiClient
 from ...exceptions import CASNetworkError, CASTimeout
 
 
@@ -12,6 +12,7 @@ class TestApiClient(TestCase):
 
     @patch('auth_backend.auth_api_client.requests.request', autospec=True)
     def test_call_raises_on_http_error(self, mock_request):
+        auth_api_client = AuthApiClient()
         mock_request.side_effect = requests.exceptions.ConnectionError
 
         with pytest.raises(CASNetworkError):
@@ -19,6 +20,7 @@ class TestApiClient(TestCase):
 
     @patch('auth_backend.auth_api_client.requests.request', autospec=True)
     def test_call_raises_on_timeout(self, mock_request):
+        auth_api_client = AuthApiClient()
         mock_request.side_effect = requests.exceptions.Timeout
 
         with pytest.raises(CASTimeout):

--- a/auth_backend/tests/unit/test_backends.py
+++ b/auth_backend/tests/unit/test_backends.py
@@ -17,14 +17,14 @@ class KagisoBackendTest(TestCase):
         profile = {
             'first_name': 'Fred'
         }
-        url, api_data = mocks.mock_out_post_users(
+        mocks.mock_out_post_users(
             1,
             email,
             profile=profile
         )
         user = KagisoUser.objects.create_user(
             email, password, profile=profile)
-        url = mocks.mock_out_post_sessions(200)
+        url, _ = mocks.mock_out_post_sessions(200)
 
         backend = KagisoBackend()
         result = backend.authenticate(email, password)
@@ -34,6 +34,38 @@ class KagisoBackendTest(TestCase):
 
         assert isinstance(result, KagisoUser)
         assert result.id == user.id
+
+    @responses.activate
+    def test_authenticate_valid_credentials_creates_local_user_if_none(self):
+        email = 'test@email.com'
+        password = 'random'
+
+        data = {
+            'id': 55,
+            'email': email,
+            'first_name': 'Fred',
+            'last_name': 'Smith',
+            'is_staff': True,
+            'is_superuser': True,
+            'profile': {'age': 40, },
+        }
+
+        _, api_data = mocks.mock_out_post_users(1, email)
+        session_url, data = mocks.mock_out_post_sessions(200, **data)
+
+        backend = KagisoBackend()
+        result = backend.authenticate(email, password)
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == session_url
+
+        assert result.id == data['id']
+        assert result.email == data['email']
+        assert result.first_name == data['first_name']
+        assert result.last_name == data['last_name']
+        assert result.is_staff == data['is_staff']
+        assert result.is_superuser == data['is_superuser']
+        assert result.profile == data['profile']
 
     @responses.activate
     def test_authenticate_invalid_status_code_raises(self):
@@ -53,11 +85,11 @@ class KagisoBackendTest(TestCase):
     def test_authenticate_with_social_sign_in_returns_user(self):
         email = 'test@email.com'
         strategy = 'facebook'
-        url, api_data = mocks.mock_out_post_users(1, email)
+        mocks.mock_out_post_users(1, email)
         # Unusable password is saved locally for Django compliance
         # It is not used for auth purposes though
         user = KagisoUser.objects.create_user(email, password='unusable')
-        url = mocks.mock_out_post_sessions(200)
+        url, data = mocks.mock_out_post_sessions(200)
 
         backend = KagisoBackend()
         result = backend.authenticate(email, strategy)
@@ -69,24 +101,12 @@ class KagisoBackendTest(TestCase):
         assert result.id == user.id
 
     @responses.activate
-    def test_authenticate_user_does_not_exist_locally_returns_none(self):
-        email = 'test@email.com'
-        password = 'random'
-
-        backend = KagisoBackend()
-        result = backend.authenticate(email, password)
-
-        assert len(responses.calls) == 0
-
-        assert not result
-
-    @responses.activate
     def test_authenticate_invalid_credentials_returns_none(self):
         email = 'test@email.com'
         password = 'incorrect'
-        url, api_data = mocks.mock_out_post_users(1, email)
+        mocks.mock_out_post_users(1, email)
         KagisoUser.objects.create_user(email, password)
-        url = mocks.mock_out_post_sessions(404)
+        url, data = mocks.mock_out_post_sessions(404)
 
         backend = KagisoBackend()
         result = backend.authenticate(email, password)

--- a/auth_backend/tests/unit/test_backends.py
+++ b/auth_backend/tests/unit/test_backends.py
@@ -27,7 +27,7 @@ class KagisoBackendTest(TestCase):
         url, _ = mocks.mock_out_post_sessions(200)
 
         backend = KagisoBackend()
-        result = backend.authenticate(email, password)
+        result = backend.authenticate(email=email, password=password)
 
         assert len(responses.calls) == 2
         assert responses.calls[1].request.url == url
@@ -54,7 +54,7 @@ class KagisoBackendTest(TestCase):
         session_url, data = mocks.mock_out_post_sessions(200, **data)
 
         backend = KagisoBackend()
-        result = backend.authenticate(email, password)
+        result = backend.authenticate(email=email, password=password)
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == session_url
@@ -79,7 +79,7 @@ class KagisoBackendTest(TestCase):
         backend = KagisoBackend()
 
         with pytest.raises(CASUnexpectedStatusCode):
-            backend.authenticate(email, password)
+            backend.authenticate(email=email, password=password)
 
     @responses.activate
     def test_authenticate_with_social_sign_in_returns_user(self):
@@ -92,7 +92,7 @@ class KagisoBackendTest(TestCase):
         url, data = mocks.mock_out_post_sessions(200)
 
         backend = KagisoBackend()
-        result = backend.authenticate(email, strategy)
+        result = backend.authenticate(email=email, strategy=strategy)
 
         assert len(responses.calls) == 2
         assert responses.calls[1].request.url == url
@@ -109,7 +109,7 @@ class KagisoBackendTest(TestCase):
         url, data = mocks.mock_out_post_sessions(404)
 
         backend = KagisoBackend()
-        result = backend.authenticate(email, password)
+        result = backend.authenticate(email=email, password=password)
 
         assert len(responses.calls) == 2
         assert responses.calls[1].request.url == url

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --nomigrations
+addopts = --reuse-db
 norecursedirs =
     build
     venv


### PR DESCRIPTION
- Use classes over module functions to encapsulate CAS credentials
- Allow credentials to be set on a KagisoUser object
- Default to non multi-tenant setup (e.g from settings file)
- If user doesnt exist locally when authenticating, but exists on CAS and credentials are valid, simply create the user locally