### PR TITLE
Create api_client when setting cas credentials

### DIFF
--- a/auth_backend/models.py
+++ b/auth_backend/models.py
@@ -31,14 +31,12 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
     objects = AuthManager()
 
     def __init__(self, *args, **kwargs):
-        self.cas_credentials = kwargs.get('cas_credentials')
-        self._auth_api_client = AuthApiClient(self.cas_credentials)
-
-        if self.cas_credentials:
-            # Django crashes if non-model fields are passed to init
-            del kwargs['cas_credentials']
-
+        self._auth_api_client = AuthApiClient()
         super().__init__(*args, **kwargs)
+
+    def override_cas_credentials(self, cas_credentials):
+        self.cas_credentials = cas_credentials
+        self._auth_api_client = AuthApiClient(self.cas_credentials)
 
     def get_full_name(self):
         return self.email

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='1.0.0',
+    version='1.1.0',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Django AuthBackend',


### PR DESCRIPTION
Previous version didnt work correctly when overriding from a queryset i.e by setting user.cas_credentials directly