### PR TITLE
Unconfirmedemails

### DIFF
--- a/auth_backend/exceptions.py
+++ b/auth_backend/exceptions.py
@@ -17,3 +17,7 @@ class CASUnexpectedStatusCode(CASError):
         self.status_code = status_code
         self.json = json
         super().__init__(message)
+
+
+class EmailNotConfirmedError(CASError):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='2.0.0',
+    version='2.1.0',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Django AuthBackend',


### PR DESCRIPTION
Raise an exception that clients can catch and use to show a pretty message prompting the user to confirm their email