### PR TITLE
Multitenancyfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='2.1.0',
+    version='2.1.1',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Django AuthBackend',


### PR DESCRIPTION
Get by Id and not email
Email doesn't support multi-tenancy and can create vexing issues if you
have one table that supports users from multiple CAS apps, and the user has signed up for say both jac and ecr