### PR TITLE
Drop twitter

### DIFF
--- a/auth_backend/forms.py
+++ b/auth_backend/forms.py
@@ -99,7 +99,6 @@ class SignUpForm(forms.Form):
         widget=forms.CheckboxSelectMultiple,
         required=False
     )
-    twitter_handle = None
 
     # --- Instance variables ---
     social_sign_in = False
@@ -113,9 +112,6 @@ class SignUpForm(forms.Form):
         if oauth_data:
             form.social_sign_in = True
             form._remove_password_fields()
-
-            if oauth_data.get('provider') == 'twitter':
-                form.twitter_handle = oauth_data['twitter_handle']
 
         return form
 
@@ -147,9 +143,6 @@ class SignUpForm(forms.Form):
         # to support multitenancy
         if self.site_id:
             user.profile['site_id'] = self.site_id
-
-        if self.twitter_handle:
-            user.profile['twitter_handle'] = self.twitter_handle
 
         user.save()
         return user

--- a/auth_backend/templates/auth_backend/sign_in.html
+++ b/auth_backend/templates/auth_backend/sign_in.html
@@ -25,14 +25,7 @@
               alt="Google Plus">
           </a>
         </li>
-        <li class="twitter">
-          <a href="{% url 'oauth' provider='twitter' %}">
-            <img
-              src="{% static 'core/images/icons/form/twitter_icon.png' %}"
-              alt="Twitter">
-          </a>
-        </li>
-      </ul>
+     </ul>
     </div>
     <form
       action="{% url 'sign_in' %}"

--- a/auth_backend/templates/auth_backend/sign_up.html
+++ b/auth_backend/templates/auth_backend/sign_up.html
@@ -32,14 +32,7 @@
               alt="Google Plus">
           </a>
         </li>
-        <li class="twitter">
-          <a href="{% url 'oauth' provider='twitter' %}">
-            <img
-              src="{% static 'core/images/icons/form/twitter_icon.png' %}"
-              alt="Twitter">
-          </a>
-        </li>
-      </ul>
+     </ul>
     </div>
     <form
       action="{% url 'sign_up' %}"

--- a/auth_backend/tests/unit/test_forms.py
+++ b/auth_backend/tests/unit/test_forms.py
@@ -131,29 +131,3 @@ class TestSignUpForm:
         assert user.profile['alerts'] == data['alerts']
 
         assert not user.set_password.called
-
-    @patch('auth_backend.forms.KagisoUser', autospec=True)
-    def test_save_twitter_sign_up_saves_twitter_handle(self, MockKagisoUser):  # noqa
-        # Twitter doesn't return an email
-        # So we link the user to their twitter handle, so they can sign in
-        # via twitter
-        oauth_data = {
-            'provider': 'twitter',
-            'twitter_handle': 'fred_smith'
-        }
-        data = {
-            'email': 'bogus@email.com',
-            'first_name': 'Fred',
-            'last_name': 'Smith',
-            'mobile': '123456789',
-            'gender': 'MALE',
-            'region': 'EASTERN_CAPE',
-            'birth_date': date(1980, 1, 31),
-            'alerts': ['EMAIL', 'SMS'],
-        }
-        form = forms.SignUpForm.create(post_data=data, oauth_data=oauth_data)
-        assert form.is_valid()
-
-        user = form.save()
-
-        assert user.profile['twitter_handle'] == oauth_data['twitter_handle']

--- a/auth_backend/tests/unit/test_views.py
+++ b/auth_backend/tests/unit/test_views.py
@@ -218,51 +218,6 @@ class OauthTest(TestCase):
 
         assert mock_authomatic.login.called
 
-    @patch('auth_backend.views.RequestContext', autospec=True)
-    @patch('auth_backend.views.Authomatic', autospec=True)
-    def test_twitter_sign_up_saves_twitter_handle_in_session(  # noqa
-            self, MockAuthomatic, MockRequestContext):
-        # Twitter doesn't return an email, so we need their Twitter handle,
-        # which we link to the user, which enables Twitter sign in
-
-        MockRequestContext.return_value = {'site_name': 'jacaranda'}
-
-        oauth_data = {
-            'email': 'test@email.com',
-            'first_name': 'Fred',
-            'last_name': 'Smith',
-            'birth_date': str(date(1980, 1, 31)),
-            'gender': 'male',
-            'screen_name': 'fred_smith',
-        }
-        mock_result = MagicMock()
-        mock_result.provider.name = 'twitter'
-        mock_result.error = None
-        mock_result.user.data = oauth_data
-
-        mock_result.user.email = oauth_data['email']
-        mock_result.user.first_name = oauth_data['first_name']
-        mock_result.user.last_name = oauth_data['last_name']
-        mock_result.user.birth_date = oauth_data['birth_date']
-        mock_result.user.gender = oauth_data['gender']
-
-        mock_authomatic = MagicMock()
-        mock_authomatic.login.return_value = mock_result
-        MockAuthomatic.return_value = mock_authomatic
-
-        response = self.client.get('/oauth/twitter/', follow=True)
-
-        # Social sign up should prefill sign up form
-        assert oauth_data['email'] in str(response.content)
-        assert oauth_data['first_name'] in str(response.content)
-        assert oauth_data['last_name'] in str(response.content)
-        assert oauth_data['gender'] in str(response.content)
-
-        # Twitter handle should be saved in the session, so once
-        # user completes Sign Up form their twitter handle gets linked
-        twitter_handle = self.client.session['oauth_data']['twitter_handle']
-        assert twitter_handle == oauth_data['screen_name']
-
     @patch('auth_backend.views.authenticate', autospec=True)
     @patch('auth_backend.views.login', autospec=True)
     @patch('auth_backend.views.KagisoUser', autospec=True)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='3.0.4',
+    version='3.1.0',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Django AuthBackend',


### PR DESCRIPTION
Twitter sign up is useless and makes a lot of hassle:
- doesnt return even an email address, so user has to fill out the entire sign up form despite expecting an instant sign in - bad ux
- does its own thing re the oauth2 spec (eg no emails!) leading to lots of conditionals
- only 4 people have signed up with twitter - no one uses it over fb and google
- we already have fb and google - more choice is bad as people forget how they signed up and then try a different provider and cant sign in 
- we constantly get complaints about people not being able to sign in, never mind they didnt confirm their email or have a password etc etc. removing twitter signin will reduce the problem surface area that we have to deal with