### PR TITLE
Single sign on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Kagiso Auth
+Django client for our Authentication API
+(https://github.com/Kagiso-Future-Media/auth)
 
 [ ![Codeship Status for Kagiso-Future-Media/django_auth](https://codeship.com/projects/f5876350-c731-0132-3b15-4a390261e3f5/status?branch=master)](https://codeship.com/projects/74869)
 [![codecov.io](https://codecov.io/github/Kagiso-Future-Media/django_auth/coverage.svg?token=LrFwE9TaXk&branch=master)](https://codecov.io/github/Kagiso-Future-Media/django_auth?branch=master)
@@ -39,13 +41,12 @@ from kagiso_auth import urls as kagiso_auth_urls
 url(r'', include(kagiso_auth_urls)),
 ```
 
-Finally you need to add your CAS credentials to settings.py.
+Finally you need to add your AUTH_API credentials to settings.py.
 In production make sure you read them in from an environment variable.
 
 ```
-CAS_TOKEN = 'your-token'
-CAS_SOURCE_ID = 'your-source-id'
-CAS_BASE_URL (optional - defaults to https://auth.kagiso.io) = 'xyz'
+AUTH_API_TOKEN = 'your-token'
+AUTH_API_BASE_URL (optional - defaults to https://auth.kagiso.io) = 'xyz'
 ```
 
 ## Testing

--- a/kagiso_auth/auth_api_client.py
+++ b/kagiso_auth/auth_api_client.py
@@ -4,7 +4,7 @@ import logging
 import requests
 
 from . import settings
-from .exceptions import CASNetworkError, CASTimeout
+from .exceptions import AuthAPINetworkError, AuthAPITimeout
 
 
 logger = logging.getLogger('django')
@@ -12,21 +12,15 @@ logger = logging.getLogger('django')
 
 class AuthApiClient:
 
-    BASE_URL = settings.CAS_BASE_URL
+    BASE_URL = settings.AUTH_API_BASE_URL
     TIMEOUT_IN_SECONDS = 6
 
-    def __init__(self, cas_credentials=None):
-        if cas_credentials is None:
-            self._cas_token = settings.CAS_TOKEN
-            self._cas_source_id = settings.CAS_SOURCE_ID
-        else:
-            self._cas_token = cas_credentials['cas_token']
-            self._cas_source_id = cas_credentials['cas_source_id']
+    def __init__(self):
+        self._auth_api_token = settings.AUTH_API_TOKEN
 
     def call(self, endpoint, method='GET', payload=None):
         auth_headers = {
-            'AUTHORIZATION': 'Token {0}'.format(self._cas_token),
-            'SOURCE-ID': self._cas_source_id,
+            'AUTHORIZATION': 'Token {0}'.format(self._auth_api_token),
         }
         url = '{base_url}/{endpoint}/.json'.format(
             base_url=self.BASE_URL,
@@ -42,9 +36,9 @@ class AuthApiClient:
                 timeout=self.TIMEOUT_IN_SECONDS
             )
         except requests.exceptions.ConnectionError as e:
-            raise CASNetworkError from e
+            raise AuthAPINetworkError from e
         except requests.exceptions.Timeout as e:
-            raise CASTimeout from e
+            raise AuthAPITimeout from e
 
         logger.debug('method={0}'.format(method))
         logger.debug('url={0}'.format(url))

--- a/kagiso_auth/auth_api_client.py
+++ b/kagiso_auth/auth_api_client.py
@@ -14,18 +14,15 @@ class AuthApiClient:
 
     BASE_URL = settings.AUTH_API_BASE_URL
     TIMEOUT_IN_SECONDS = 6
+    AUTH_API_TOKEN = settings.AUTH_API_TOKEN
 
-    def __init__(self):
-        self._auth_api_token = settings.AUTH_API_TOKEN
-
-    def call(self, endpoint, method='GET', payload=None):
+    @classmethod
+    def call(cls, endpoint, method='GET', payload=None):
         auth_headers = {
-            'AUTHORIZATION': 'Token {0}'.format(self._auth_api_token),
+            'AUTHORIZATION': 'Token {0}'.format(cls.AUTH_API_TOKEN),
         }
-        print(self._auth_api_token)
-        print(self.BASE_URL)
         url = '{base_url}/{endpoint}/.json'.format(
-            base_url=self.BASE_URL,
+            base_url=cls.BASE_URL,
             endpoint=endpoint
         )
 
@@ -35,7 +32,7 @@ class AuthApiClient:
                 url,
                 headers=auth_headers,
                 json=payload,
-                timeout=self.TIMEOUT_IN_SECONDS
+                timeout=cls.TIMEOUT_IN_SECONDS
             )
         except requests.exceptions.ConnectionError as e:
             raise AuthAPINetworkError from e

--- a/kagiso_auth/auth_api_client.py
+++ b/kagiso_auth/auth_api_client.py
@@ -22,6 +22,8 @@ class AuthApiClient:
         auth_headers = {
             'AUTHORIZATION': 'Token {0}'.format(self._auth_api_token),
         }
+        print(self._auth_api_token)
+        print(self.BASE_URL)
         url = '{base_url}/{endpoint}/.json'.format(
             base_url=self.BASE_URL,
             endpoint=endpoint

--- a/kagiso_auth/backends.py
+++ b/kagiso_auth/backends.py
@@ -38,9 +38,9 @@ class KagisoBackend(ModelBackend):
         if status == http.HTTP_200_OK:
             user = KagisoUser.objects.filter(id=data['id']).first()
             if not user:
-                user = KagisoUser.sync_from_auth_db_locally(data)
+                user = KagisoUser.sync_user_data_locally(data)
 
-            user.last_sign_in_via = settings.APP_NAME
+            user.last_sign_in_via = kwargs['app_name']
             user.save()
         elif status == http.HTTP_404_NOT_FOUND:
             return None

--- a/kagiso_auth/backends.py
+++ b/kagiso_auth/backends.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 from django.db.models.signals import pre_save
 
@@ -51,6 +52,9 @@ class KagisoBackend(ModelBackend):
                     local_user.save()
                 finally:
                     pre_save.connect(save_user_to_auth_api, sender=KagisoUser)
+
+            local_user.last_sign_in_via = settings.APP_NAME
+            local_user.save()
         elif status == http.HTTP_404_NOT_FOUND:
             return None
         elif status == http.HTTP_422_UNPROCESSABLE_ENTITY:

--- a/kagiso_auth/backends.py
+++ b/kagiso_auth/backends.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 
 from . import http
@@ -36,12 +35,7 @@ class KagisoBackend(ModelBackend):
         status, data = auth_api_client.call('sessions', 'POST', payload)
 
         if status == http.HTTP_200_OK:
-            user = KagisoUser.objects.filter(id=data['id']).first()
-            if not user:
-                user = KagisoUser.sync_user_data_locally(data)
-
-            user.last_sign_in_via = kwargs['app_name']
-            user.save()
+            user = KagisoUser.sync_user_data_locally(data)
         elif status == http.HTTP_404_NOT_FOUND:
             return None
         elif status == http.HTTP_422_UNPROCESSABLE_ENTITY:

--- a/kagiso_auth/exceptions.py
+++ b/kagiso_auth/exceptions.py
@@ -1,16 +1,16 @@
-class CASError(Exception):
+class AuthAPIError(Exception):
     pass
 
 
-class CASNetworkError(CASError):
+class AuthAPINetworkError(AuthAPIError):
     pass
 
 
-class CASTimeout(CASError):
+class AuthAPITimeout(AuthAPIError):
     pass
 
 
-class CASUnexpectedStatusCode(CASError):
+class AuthAPIUnexpectedStatusCode(AuthAPIError):
 
     def __init__(self, status_code, json):
         message = 'Status: {0}.\nJson: {1}'.format(status_code, json)
@@ -19,5 +19,5 @@ class CASUnexpectedStatusCode(CASError):
         super().__init__(message)
 
 
-class EmailNotConfirmedError(CASError):
+class EmailNotConfirmedError(AuthAPIError):
     pass

--- a/kagiso_auth/forms.py
+++ b/kagiso_auth/forms.py
@@ -102,7 +102,6 @@ class SignUpForm(forms.Form):
 
     # --- Instance variables ---
     social_sign_in = False
-    site_id = None  # Wagtail only
 
     @classmethod
     def create(cls, post_data=None, oauth_data=None):
@@ -119,9 +118,8 @@ class SignUpForm(forms.Form):
         validate_passwords_match(self)
         return self.cleaned_data
 
-    def save(self, cas_credentials=None):
+    def save(self):
         user = KagisoUser()
-        user.override_cas_credentials(cas_credentials)
         user.email = self.cleaned_data['email']
 
         if self.social_sign_in:
@@ -138,11 +136,6 @@ class SignUpForm(forms.Form):
             'birth_date': str(self.cleaned_data['birth_date']),
             'alerts': self.cleaned_data['alerts'],
         }
-
-        # If we are using Wagtail keep track of which site it it
-        # to support multitenancy
-        if self.site_id:
-            user.profile['site_id'] = self.site_id
 
         user.save()
         return user

--- a/kagiso_auth/forms.py
+++ b/kagiso_auth/forms.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from django import forms
-from django.conf import settings
 from django.forms.extras import widgets
 from django.utils import timezone
 
@@ -119,7 +118,7 @@ class SignUpForm(forms.Form):
         validate_passwords_match(self)
         return self.cleaned_data
 
-    def save(self):
+    def save(self, app_name):
         user = KagisoUser()
         user.email = self.cleaned_data['email']
 
@@ -137,7 +136,7 @@ class SignUpForm(forms.Form):
             'birth_date': str(self.cleaned_data['birth_date']),
             'alerts': self.cleaned_data['alerts'],
         }
-        user.created_via = settings.APP_NAME
+        user.created_via = app_name
 
         user.save()
         return user

--- a/kagiso_auth/forms.py
+++ b/kagiso_auth/forms.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django import forms
+from django.conf import settings
 from django.forms.extras import widgets
 from django.utils import timezone
 
@@ -136,6 +137,7 @@ class SignUpForm(forms.Form):
             'birth_date': str(self.cleaned_data['birth_date']),
             'alerts': self.cleaned_data['alerts'],
         }
+        user.created_via = settings.APP_NAME
 
         user.save()
         return user

--- a/kagiso_auth/migrations/0007_auto_20151130_1043.py
+++ b/kagiso_auth/migrations/0007_auto_20151130_1043.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kagiso_auth', '0006_auto_20150514_1045'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='kagisouser',
+            old_name='date_joined',
+            new_name='created',
+        ),
+        migrations.AddField(
+            model_name='kagisouser',
+            name='created_via',
+            field=models.CharField(null=True, max_length=100, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='kagisouser',
+            name='last_sign_in_via',
+            field=models.CharField(null=True, max_length=100, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/kagiso_auth/models.py
+++ b/kagiso_auth/models.py
@@ -62,7 +62,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
         if status == http.HTTP_200_OK:
             user = KagisoUser.objects.filter(email=email).first()
             if not user:
-                user = KagisoUser.sync_from_auth_db_locally(data)
+                user = KagisoUser.sync_user_data_locally(data)
             return user
         elif status == http.HTTP_404_NOT_FOUND:
             return None
@@ -70,13 +70,15 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
             raise AuthAPIUnexpectedStatusCode(status, data)
 
     @staticmethod
-    def sync_from_auth_db_locally(data):
+    def sync_user_data_locally(data):
         try:
             pre_save.disconnect(
                 save_user_to_auth_api,
                 sender=KagisoUser
             )
-            user = KagisoUser()
+            user = KagisoUser.objects.filter(
+                id=data['id']
+            ).first() or KagisoUser()
             user.build_from_auth_api_data(data)
             user.save()
             return user

--- a/kagiso_auth/models.py
+++ b/kagiso_auth/models.py
@@ -55,7 +55,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
         self.raw_password = raw_password
 
     @staticmethod
-    def exists_in_auth_db(email):
+    def get_user_from_auth_db(email):
         endpoint = 'users/{email}'.format(email=email)
         status, data = AuthApiClient.call(endpoint, 'GET')
 
@@ -65,7 +65,7 @@ class KagisoUser(AbstractBaseUser, PermissionsMixin):
                 user = KagisoUser.sync_from_auth_db_locally(data)
             return user
         elif status == http.HTTP_404_NOT_FOUND:
-            return False
+            return None
         else:
             raise AuthAPIUnexpectedStatusCode(status, data)
 

--- a/kagiso_auth/settings.py
+++ b/kagiso_auth/settings.py
@@ -2,18 +2,14 @@ import os
 
 from django.conf import settings
 
-CAS_TOKEN = os.getenv('CAS_TOKEN') or getattr(
+AUTH_API_TOKEN = os.getenv('AUTH_API_TOKEN') or getattr(
     settings,
-    'CAS_TOKEN',
+    'AUTH_API_TOKEN',
     'CHANGEME'
 )
-CAS_SOURCE_ID = os.getenv('CAS_SOURCE_ID') or getattr(
+
+AUTH_API_BASE_URL = os.getenv('AUTH_API_BASE_URL') or getattr(
     settings,
-    'CAS_SOURCE_ID',
-    'CHANGEME'
-)
-CAS_BASE_URL = os.getenv('CAS_BASE_URL') or getattr(
-    settings,
-    'CAS_BASE_URL',
+    'AUTH_API_BASE_URL',
     'https://auth.kagiso.io/api/v1'
 )

--- a/kagiso_auth/tests/integration/test_integration.py
+++ b/kagiso_auth/tests/integration/test_integration.py
@@ -24,8 +24,6 @@ class KagisoUserTest(TestCase):
             email=email,
             first_name='George',
             last_name='Smith',
-            is_staff=True,
-            is_superuser=True,
             profile=profile,
         )
         user.set_password(password)
@@ -38,8 +36,6 @@ class KagisoUserTest(TestCase):
         assert result.email == user.email
         assert result.first_name == user.first_name
         assert result.last_name == user.last_name
-        assert result.is_staff
-        assert result.is_superuser
         assert not result.confirmation_token
         assert result.profile == profile
 

--- a/kagiso_auth/tests/integration/test_integration.py
+++ b/kagiso_auth/tests/integration/test_integration.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import TestCase
 from model_mommy import mommy
 import pytest
@@ -25,6 +26,7 @@ class KagisoUserTest(TestCase):
             first_name='George',
             last_name='Smith',
             profile=profile,
+            created_via=settings.APP_NAME
         )
         user.set_password(password)
         user.save()
@@ -38,6 +40,7 @@ class KagisoUserTest(TestCase):
         assert result.last_name == user.last_name
         assert not result.confirmation_token
         assert result.profile == profile
+        assert result.created_via == user.created_via
 
         # ----- Unconfirmed users can't sign in -----
         with pytest.raises(EmailNotConfirmedError):
@@ -61,6 +64,7 @@ class KagisoUserTest(TestCase):
             password=password
         )
         assert signed_in_user == user
+        assert signed_in_user.last_sign_in_via == settings.APP_NAME
 
         # ----- Update user -----
         new_email = utils.random_email()

--- a/kagiso_auth/tests/settings/test.py
+++ b/kagiso_auth/tests/settings/test.py
@@ -5,8 +5,7 @@ DEBUG = True
 SECRET_KEY = '^7jcx7^h#b@%a76lr@a2!7xj#@4@5ayuyan9c$y#(_(8l3)_%t'
 UNIT_TEST_SETTINGS = True
 
-JAC_CAS_TOKEN = 'xyz'
-JAC_CAS_SOURCE_ID = 'xyz'
+AUTH_API_TOKEN = 'xyz'
 
 INSTALLED_APPS = (
     'django.contrib.admin',
@@ -85,6 +84,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 AUTH_USER_MODEL = 'kagiso_auth.KagisoUser'
+SIGN_UP_EMAIL_TEMPLATE = 'xyz'
+PASSWORD_RESET_EMAIL_TEMPLATE = 'xyz'
 
 # Authomatic is mocked out in the tests, but a key lookup is still
 # performed to get settings, so pass a stub back

--- a/kagiso_auth/tests/settings/test.py
+++ b/kagiso_auth/tests/settings/test.py
@@ -83,6 +83,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
 STATIC_URL = '/static/'
+
+APP_NAME = 'Test App'
 AUTH_USER_MODEL = 'kagiso_auth.KagisoUser'
 SIGN_UP_EMAIL_TEMPLATE = 'xyz'
 PASSWORD_RESET_EMAIL_TEMPLATE = 'xyz'

--- a/kagiso_auth/tests/test_utils.py
+++ b/kagiso_auth/tests/test_utils.py
@@ -1,0 +1,18 @@
+from ..utils import get_setting
+
+
+def test_get_setting_with_primitive():
+    setting = 'abc'
+
+    result = get_setting(setting, None)
+
+    assert result == setting
+
+
+def test_get_setting_with_lambda():
+    setting = lambda request: request
+    request = object()
+
+    result = get_setting(setting, request)
+
+    assert result == request

--- a/kagiso_auth/tests/unit/mocks.py
+++ b/kagiso_auth/tests/unit/mocks.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 import responses
 
 from ... import http
@@ -17,6 +18,7 @@ def post_users(id, email, status=http.HTTP_201_CREATED, **kwargs):
         'confirmation_token': '49:1YkTO2:1VuxvGJre66xqQj6rkEXewmVs08',
         'email_confirmed': None,
         'profile': kwargs.get('profile'),
+        'created_via': settings.APP_NAME,
         'created': '2015-04-21T08:18:30.368602Z',
         'modified': '2015-04-21T08:18:30.374410Z'
     }
@@ -42,7 +44,9 @@ def put_users(id, email, status=http.HTTP_200_OK, **kwargs):
         'is_superuser': kwargs.get('is_superuser', False),
         'profile': kwargs.get('profile'),
         'created': '2015-04-21T08:18:30.368602Z',
-        'modified': '2015-04-21T08:18:30.374410Z'
+        'created_via': kwargs.get('created_via'),
+        'modified': '2015-04-21T08:18:30.374410Z',
+        'last_sign_in_via': kwargs.get('last_sign_in_via'),
     }
 
     responses.add(
@@ -135,7 +139,9 @@ def post_sessions(status=http.HTTP_200_OK, **kwargs):
         'email_confirmed': None,
         'profile': kwargs.get('profile'),
         'created': '2015-04-21T08:18:30.368602Z',
-        'modified': '2015-04-21T08:18:30.374410Z'
+        'created_via': kwargs.get('created_via'),
+        'modified': '2015-04-21T08:18:30.374410Z',
+        'last_sign_in_via': kwargs.get('last_sign_in_via'),
     }
 
     responses.add(

--- a/kagiso_auth/tests/unit/mocks.py
+++ b/kagiso_auth/tests/unit/mocks.py
@@ -6,6 +6,33 @@ import responses
 from ... import http
 
 
+def get_user_by_email(id, email, status=http.HTTP_200_OK, **kwargs):
+    url = 'https://auth.kagiso.io/api/v1/users/{email}/.json'.format(email=email)  # noqa
+    data = {
+        'id': id,
+        'email': email,
+        'first_name': kwargs.get('first_name', ''),
+        'last_name': kwargs.get('last_name', ''),
+        'is_staff': kwargs.get('is_staff', False),
+        'is_superuser': kwargs.get('is_superuser', False),
+        'confirmation_token': '49:1YkTO2:1VuxvGJre66xqQj6rkEXewmVs08',
+        'email_confirmed': None,
+        'profile': kwargs.get('profile'),
+        'created_via': settings.APP_NAME,
+        'created': '2015-04-21T08:18:30.368602Z',
+        'modified': '2015-04-21T08:18:30.374410Z'
+    }
+
+    responses.add(
+        responses.GET,
+        url,
+        body=json.dumps(data),
+        status=status
+    )
+
+    return url, data
+
+
 def post_users(id, email, status=http.HTTP_201_CREATED, **kwargs):
     url = 'https://auth.kagiso.io/api/v1/users/.json'
     data = {

--- a/kagiso_auth/tests/unit/test_auth_api_client.py
+++ b/kagiso_auth/tests/unit/test_auth_api_client.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 
 from ...auth_api_client import AuthApiClient
-from ...exceptions import CASNetworkError, CASTimeout
+from ...exceptions import AuthAPINetworkError, AuthAPITimeout
 
 
 class TestApiClient(TestCase):
@@ -15,7 +15,7 @@ class TestApiClient(TestCase):
         auth_api_client = AuthApiClient()
         mock_request.side_effect = requests.exceptions.ConnectionError
 
-        with pytest.raises(CASNetworkError):
+        with pytest.raises(AuthAPINetworkError):
             auth_api_client.call('/endpoint/')
 
     @patch('kagiso_auth.auth_api_client.requests.request', autospec=True)
@@ -23,5 +23,5 @@ class TestApiClient(TestCase):
         auth_api_client = AuthApiClient()
         mock_request.side_effect = requests.exceptions.Timeout
 
-        with pytest.raises(CASTimeout):
+        with pytest.raises(AuthAPITimeout):
             auth_api_client.call('/endpoint/')

--- a/kagiso_auth/tests/unit/test_backends.py
+++ b/kagiso_auth/tests/unit/test_backends.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from django.conf import settings
 from django.test import TestCase
 import pytest
 import responses
-from unittest.mock import patch
 
 from . import mocks
 from ... import http

--- a/kagiso_auth/tests/unit/test_backends.py
+++ b/kagiso_auth/tests/unit/test_backends.py
@@ -30,7 +30,11 @@ class KagisoBackendTest(TestCase):
         )
 
         backend = KagisoBackend()
-        result = backend.authenticate(email=email, password=password)
+        result = backend.authenticate(
+            email=email,
+            password=password,
+            app_name=settings.APP_NAME
+        )
 
         assert len(responses.calls) == 3
         assert responses.calls[1].request.url == url
@@ -64,7 +68,11 @@ class KagisoBackendTest(TestCase):
         mocks.put_users(**data)
 
         backend = KagisoBackend()
-        result = backend.authenticate(email=email, password=password)
+        result = backend.authenticate(
+            email=email,
+            password=password,
+            app_name=settings.APP_NAME
+        )
 
         assert len(responses.calls) == 2
         assert responses.calls[0].request.url == session_url
@@ -83,7 +91,11 @@ class KagisoBackendTest(TestCase):
         backend = KagisoBackend()
 
         with pytest.raises(AuthAPIUnexpectedStatusCode):
-            backend.authenticate(email=email, password=password)
+            backend.authenticate(
+                email=email,
+                password=password,
+                app_name=settings.APP_NAME
+            )
 
     @responses.activate
     def test_authenticate_with_social_sign_in_returns_user(self):
@@ -97,7 +109,11 @@ class KagisoBackendTest(TestCase):
         mocks.put_users(1, email)
 
         backend = KagisoBackend()
-        result = backend.authenticate(email=email, strategy=strategy)
+        result = backend.authenticate(
+            email=email,
+            strategy=strategy,
+            app_name=settings.APP_NAME
+        )
 
         assert len(responses.calls) == 3
         assert responses.calls[1].request.url == url

--- a/kagiso_auth/tests/unit/test_backends.py
+++ b/kagiso_auth/tests/unit/test_backends.py
@@ -5,7 +5,7 @@ import responses
 from . import mocks
 from ... import http
 from ...backends import KagisoBackend
-from ...exceptions import CASUnexpectedStatusCode, EmailNotConfirmedError
+from ...exceptions import AuthAPIUnexpectedStatusCode, EmailNotConfirmedError
 from ...models import KagisoUser
 
 
@@ -82,7 +82,7 @@ class KagisoBackendTest(TestCase):
 
         backend = KagisoBackend()
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             backend.authenticate(email=email, password=password)
 
     @responses.activate

--- a/kagiso_auth/tests/unit/test_backends.py
+++ b/kagiso_auth/tests/unit/test_backends.py
@@ -69,15 +69,7 @@ class KagisoBackendTest(TestCase):
         assert len(responses.calls) == 2
         assert responses.calls[0].request.url == session_url
 
-        assert result.id == data['id']
         assert result.email == data['email']
-        assert result.first_name == data['first_name']
-        assert result.last_name == data['last_name']
-        assert result.is_staff == data['is_staff']
-        assert result.is_superuser == data['is_superuser']
-        assert result.profile == data['profile']
-        assert result.created_via == settings.APP_NAME
-        assert result.last_sign_in_via == settings.APP_NAME
 
     @responses.activate
     def test_authenticate_invalid_status_code_raises(self):

--- a/kagiso_auth/tests/unit/test_forms.py
+++ b/kagiso_auth/tests/unit/test_forms.py
@@ -49,7 +49,7 @@ class TestSignUpForm:
         assert 'confirm_password' not in form.fields
 
     @patch('kagiso_auth.forms.KagisoUser', autospec=True)
-    def test_save_regular_sign_up_from_regular_django_site(self, MockKagisoUser):  # noqa
+    def test_save_regular_sign_up(self, MockKagisoUser):  # noqa
         data = {
             'email': 'bogus@email.com',
             'first_name': 'Fred',
@@ -78,29 +78,6 @@ class TestSignUpForm:
         assert user.profile['alerts'] == data['alerts']
 
         user.set_password.assert_called_with(data['password'])
-
-    @patch('kagiso_auth.forms.KagisoUser', autospec=True)
-    def test_save_regular_sign_up_from_wagtail_site(self, MockKagisoUser):  # noqa
-        site_id = 55
-        data = {
-            'email': 'bogus@email.com',
-            'first_name': 'Fred',
-            'last_name': 'Smith',
-            'password': 'mypassword',
-            'confirm_password': 'mypassword',
-            'mobile': '123456789',
-            'gender': 'MALE',
-            'region': 'EASTERN_CAPE',
-            'birth_date': date(1980, 1, 31),
-            'alerts': ['EMAIL', 'SMS'],
-        }
-        form = forms.SignUpForm.create(post_data=data)
-        form.site_id = site_id
-        assert form.is_valid()
-
-        user = form.save()
-
-        assert user.profile['site_id'] == site_id
 
     @patch('kagiso_auth.forms.KagisoUser', autospec=True)
     def test_save_social_sign_up(self, MockKagisoUser):  # noqa

--- a/kagiso_auth/tests/unit/test_forms.py
+++ b/kagiso_auth/tests/unit/test_forms.py
@@ -67,7 +67,7 @@ class TestSignUpForm:
 
         assert form.is_valid()
 
-        user = form.save()
+        user = form.save(app_name=settings.APP_NAME)
 
         assert user.email == data['email']
         assert user.first_name == data['first_name']
@@ -97,7 +97,7 @@ class TestSignUpForm:
         form = forms.SignUpForm.create(post_data=data, oauth_data=data)
         assert form.is_valid()
 
-        user = form.save()
+        user = form.save(app_name=settings.APP_NAME)
 
         assert user.email == data['email']
         assert user.email_confirmed

--- a/kagiso_auth/tests/unit/test_forms.py
+++ b/kagiso_auth/tests/unit/test_forms.py
@@ -2,6 +2,7 @@ from datetime import date
 from unittest.mock import patch
 
 from django import forms as django_forms
+from django.conf import settings
 
 from ... import forms
 
@@ -76,6 +77,7 @@ class TestSignUpForm:
         assert user.profile['region'] == data['region']
         assert user.profile['birth_date'] == str(data['birth_date'])
         assert user.profile['alerts'] == data['alerts']
+        assert user.created_via == settings.APP_NAME
 
         user.set_password.assert_called_with(data['password'])
 
@@ -106,5 +108,6 @@ class TestSignUpForm:
         assert user.profile['region'] == data['region']
         assert user.profile['birth_date'] == str(data['birth_date'])
         assert user.profile['alerts'] == data['alerts']
+        assert user.created_via == settings.APP_NAME
 
         assert not user.set_password.called

--- a/kagiso_auth/tests/unit/test_managers.py
+++ b/kagiso_auth/tests/unit/test_managers.py
@@ -44,7 +44,7 @@ class KagisoUserTest(TestCase):
         assert result.confirmation_token == api_data['confirmation_token']
         assert not result.email_confirmed
         assert result.profile == profile
-        assert result.date_joined == parser.parse(api_data['created'])
+        assert result.created == parser.parse(api_data['created'])
         assert result.modified == parser.parse(api_data['modified'])
 
     @responses.activate

--- a/kagiso_auth/tests/unit/test_models.py
+++ b/kagiso_auth/tests/unit/test_models.py
@@ -7,7 +7,7 @@ import responses
 
 from . import mocks
 from ... import http, models
-from ...exceptions import CASUnexpectedStatusCode
+from ...exceptions import AuthAPIUnexpectedStatusCode
 
 
 class KagisoUserTest(TestCase):
@@ -76,7 +76,7 @@ class KagisoUserTest(TestCase):
         assert result.modified == parser.parse(api_data['modified'])
 
     @responses.activate
-    def test_create_raises_if_user_exists_on_cas(self):
+    def test_create_raises_if_user_exists_on_auth_api(self):
         email = 'test@email.com'
         data = {
             'first_name': 'Fred',
@@ -111,7 +111,7 @@ class KagisoUserTest(TestCase):
             status=http.HTTP_500_INTERNAL_SERVER_ERROR
         )
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             mommy.make(
                 models.KagisoUser,
                 id=None,
@@ -176,7 +176,7 @@ class KagisoUserTest(TestCase):
         assert result.modified == parser.parse(api_data['modified'])
 
     @responses.activate
-    def test_update_syncs_if_user_doesnt_exist_on_cas(self):
+    def test_update_syncs_if_user_doesnt_exist_on_auth_api(self):
         # ------------------------
         # -------Arrange----------
         # ------------------------
@@ -242,7 +242,7 @@ class KagisoUserTest(TestCase):
 
         user.email = email
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             user.save()
 
     @responses.activate
@@ -268,7 +268,7 @@ class KagisoUserTest(TestCase):
         mocks.delete_users(
             user.id, status=http.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             user.delete()
 
     def test_get_full_name_returns_email(self):
@@ -337,7 +337,7 @@ class KagisoUserTest(TestCase):
         mocks.post_confirm_email(
             status=http.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             user.confirm_email(post_data['confirmation_token'])
 
         assert not user.email_confirmed
@@ -364,7 +364,7 @@ class KagisoUserTest(TestCase):
             user.email,
             http.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             token = user.regenerate_confirmation_token()
             assert token is None
 
@@ -388,7 +388,7 @@ class KagisoUserTest(TestCase):
         url, data = mocks.get_reset_password(
             user.email, status=http.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             reset_password_token = user.generate_reset_password_token()
             assert reset_password_token is None
 
@@ -412,7 +412,7 @@ class KagisoUserTest(TestCase):
         mocks.post_reset_password(
             user.email, status=http.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             did_password_reset = user.reset_password(
                 'new_password',
                 'test_token'
@@ -442,6 +442,6 @@ class KagisoUserTest(TestCase):
         mocks.delete_sessions(
             id, status=http.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        with pytest.raises(CASUnexpectedStatusCode):
+        with pytest.raises(AuthAPIUnexpectedStatusCode):
             did_sign_out = user.record_sign_out()
             assert not did_sign_out

--- a/kagiso_auth/tests/unit/test_models.py
+++ b/kagiso_auth/tests/unit/test_models.py
@@ -311,11 +311,11 @@ class KagisoUserTest(TestCase):
         assert user.email == username
 
     @responses.activate
-    def test_exists_in_auth_db_returns_user_if_exists(self):
+    def test_get_user_from_auth_db_returns_user_if_exists(self):
         email = 'test@email.com'
         url, _ = mocks.get_user_by_email(1, email)
 
-        result = KagisoUser.exists_in_auth_db(email)
+        result = KagisoUser.get_user_from_auth_db(email)
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == url
@@ -323,11 +323,11 @@ class KagisoUserTest(TestCase):
         assert result.email == email
 
     @responses.activate
-    def test_exists_in_auth_db_returns_false_if_not_exists(self):
+    def test_get_user_from_auth_db_returns_none_if_not_exists(self):
         email = 'test@email.com'
         url, _ = mocks.get_user_by_email(1, email, http.HTTP_404_NOT_FOUND)
 
-        result = KagisoUser.exists_in_auth_db(email)
+        result = KagisoUser.get_user_from_auth_db(email)
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == url
@@ -335,7 +335,7 @@ class KagisoUserTest(TestCase):
         assert not result
 
     @responses.activate
-    def test_exists_in_auth_db_invalid_status_code_raises(self):
+    def test_get_user_from_auth_db_invalid_status_code_raises(self):
         email = 'test@email.com'
         url, _ = mocks.get_user_by_email(
             1,
@@ -344,7 +344,7 @@ class KagisoUserTest(TestCase):
         )
 
         with pytest.raises(AuthAPIUnexpectedStatusCode):
-            KagisoUser.exists_in_auth_db(email)
+            KagisoUser.get_user_from_auth_db(email)
 
     @responses.activate
     def test_sync_from_auth_db_locally_syncs_if_no_local_user(self):

--- a/kagiso_auth/tests/unit/test_models.py
+++ b/kagiso_auth/tests/unit/test_models.py
@@ -347,7 +347,7 @@ class KagisoUserTest(TestCase):
             KagisoUser.get_user_from_auth_db(email)
 
     @responses.activate
-    def test_sync_from_auth_db_locally_syncs_if_no_local_user(self):
+    def test_sync_user_data_locally_syncs_if_no_local_user(self):
         email = 'test@email.com'
 
         data = {
@@ -364,7 +364,7 @@ class KagisoUserTest(TestCase):
             'last_sign_in_via': settings.APP_NAME
         }
 
-        KagisoUser.sync_from_auth_db_locally(data)
+        KagisoUser.sync_user_data_locally(data)
 
         result = KagisoUser.objects.get(email=email)
 

--- a/kagiso_auth/tests/unit/test_models.py
+++ b/kagiso_auth/tests/unit/test_models.py
@@ -1,4 +1,5 @@
 from dateutil import parser
+from django.conf import settings
 from django.db.utils import IntegrityError
 from django.test import TestCase
 from model_mommy import mommy
@@ -34,7 +35,7 @@ class KagisoUserTest(TestCase):
             last_name=last_name,
             is_staff=is_staff,
             is_superuser=is_superuser,
-            profile=profile
+            profile=profile,
         )
         # ------------------------
         # -------Act--------------
@@ -72,7 +73,8 @@ class KagisoUserTest(TestCase):
         assert not result.email_confirmed
         assert result.confirmation_token is None
         assert result.profile == api_data['profile']
-        assert result.date_joined == parser.parse(api_data['created'])
+        assert result.created == parser.parse(api_data['created'])
+        assert result.created_via == settings.APP_NAME
         assert result.modified == parser.parse(api_data['modified'])
 
     @responses.activate
@@ -143,7 +145,8 @@ class KagisoUserTest(TestCase):
             last_name=last_name,
             is_staff=is_staff,
             is_superuser=is_superuser,
-            profile=profile
+            profile=profile,
+            last_sign_in_via=settings.APP_NAME
         )
 
         # ------------------------
@@ -156,6 +159,7 @@ class KagisoUserTest(TestCase):
         user.is_staff = is_staff
         user.is_superuser = is_superuser
         user.profile = profile
+        user.last_sign_in_via = settings.APP_NAME
         user.save()
 
         # ------------------------
@@ -174,6 +178,7 @@ class KagisoUserTest(TestCase):
         assert result.is_superuser == api_data['is_superuser']
         assert result.profile == api_data['profile']
         assert result.modified == parser.parse(api_data['modified'])
+        assert result.last_sign_in_via == api_data['last_sign_in_via']
 
     @responses.activate
     def test_update_syncs_if_user_doesnt_exist_on_auth_api(self):

--- a/kagiso_auth/tests/unit/test_views.py
+++ b/kagiso_auth/tests/unit/test_views.py
@@ -179,13 +179,8 @@ class SignInTest(TestCase):
 
 class OauthTest(TestCase):
 
-    @patch('kagiso_auth.views.RequestContext', autospec=True)
     @patch('kagiso_auth.views.Authomatic', autospec=True)
-    def test_new_user_redirects_to_sign_up_page(  # noqa
-            self, MockAuthomatic, MockRequestContext):
-
-        MockRequestContext.return_value = {'site_name': 'jacaranda'}
-
+    def test_new_user_redirects_to_sign_up_page(self, MockAuthomatic):  # noqa
         oauth_data = {
             'email': 'test@email.com',
             'first_name': 'Fred',
@@ -221,12 +216,10 @@ class OauthTest(TestCase):
     @patch('kagiso_auth.views.authenticate', autospec=True)
     @patch('kagiso_auth.views.login', autospec=True)
     @patch('kagiso_auth.views.KagisoUser', autospec=True)
-    @patch('kagiso_auth.views.RequestContext', autospec=True)
     @patch('kagiso_auth.views.Authomatic', autospec=True)
     def test_existing_user_gets_signed_in(  # noqa
             self,
             MockAuthomatic,
-            MockRequestContext,
             MockKagisoUser,
             mock_login,
             mock_authenticate):
@@ -235,8 +228,6 @@ class OauthTest(TestCase):
         user.save = MagicMock()
         # Raw returns a QuerySet...
         MockKagisoUser.objects.raw.return_value = [user]
-
-        MockRequestContext.return_value = {'site_name': 'jacaranda'}
 
         mock_result = MagicMock()
         mock_result.error = None
@@ -256,10 +247,8 @@ class OauthTest(TestCase):
 
 class SignOutTest(TestCase):
 
-    @patch('kagiso_auth.views.RequestContext', autospec=True)
     @patch('kagiso_auth.views.logout', autospec=True)
-    def test_sign_out(self, mock_logout, MockRequestContext):  # noqa
-        MockRequestContext.return_value = {'site_name': 'jacaranda'}
+    def test_sign_out(self, mock_logout):
         site = MagicMock()
         site.hostname = 'jacarandafm.com'
         user = KagisoUser()

--- a/kagiso_auth/tests/unit/test_views.py
+++ b/kagiso_auth/tests/unit/test_views.py
@@ -210,7 +210,7 @@ class OauthTest(TestCase):
         mock_authomatic.login.return_value = mock_result
         MockAuthomatic.return_value = mock_authomatic
 
-        MockKagisoUser.exists_in_auth_db.return_value = False
+        MockKagisoUser.get_user_from_auth_db.return_value = None
 
         response = self.client.get('/oauth/facebook/', follow=True)
 
@@ -304,7 +304,7 @@ class ForgotPasswordTest(TestCase):
 
     @patch('kagiso_auth.views.KagisoUser', autospec=True)
     def test_forgot_password_post_user_not_found(self, MockKagisoUser):  # noqa
-        MockKagisoUser.exists_in_auth_db.return_value = False
+        MockKagisoUser.get_user_from_auth_db.return_value = None
         data = {'email': 'no@user.com'}
 
         response = self.client.post('/forgot_password/', data, follow=True)
@@ -320,7 +320,7 @@ class ForgotPasswordTest(TestCase):
 
         user = KagisoUser(email=email)
         user.generate_reset_password_token = MagicMock(return_value='token')
-        MockKagisoUser.exists_in_auth_db.return_value = user
+        MockKagisoUser.get_user_from_auth_db.return_value = user
 
         data = {'email': email}
 

--- a/kagiso_auth/tests/unit/test_views.py
+++ b/kagiso_auth/tests/unit/test_views.py
@@ -53,9 +53,10 @@ class SignUpTest(TestCase):
         assert mock_user.profile['birth_date'] == str(data['birth_date'])
         assert mock_user.profile['alerts'] == data['alerts']
 
-        assert 'You will receive an email with confirmation instructions shortly.' \
-            'This link will expire within 24 hours.' \
-            == message
+        assert (
+            'You will receive an email with confirmation instructions shortly. '  # noqa
+            'This link will expire within 24 hours.'
+        ) == message
 
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to[0] == mock_user.email
@@ -154,9 +155,10 @@ class SignInTest(TestCase):
         message = list(response.context['messages'])[0].message
 
         assert response.status_code == 200
-        assert 'You will receive an email with confirmation instructions shortly.' \
-            'This link will expire within 24 hours.'\
-            == message
+        assert (
+            'You will receive an email with confirmation instructions shortly. '  # noqa
+            'This link will expire within 24 hours.'
+        ) == message
 
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to[0] == email

--- a/kagiso_auth/tests/unit/test_views.py
+++ b/kagiso_auth/tests/unit/test_views.py
@@ -228,8 +228,6 @@ class OauthTest(TestCase):
 
         user = KagisoUser(email='test@email.com')
         user.save = MagicMock()
-        # Raw returns a QuerySet...
-        MockKagisoUser.objects.raw.return_value = [user]
 
         mock_result = MagicMock()
         mock_result.error = None
@@ -245,6 +243,27 @@ class OauthTest(TestCase):
         assert mock_authomatic.login.called
         assert mock_login.called
         assert mock_authenticate.called
+
+    @patch('kagiso_auth.views.authenticate', autospec=True)
+    @patch('kagiso_auth.views.login', autospec=True)
+    @patch('kagiso_auth.views.KagisoUser', autospec=True)
+    @patch('kagiso_auth.views.Authomatic', autospec=True)
+    def test_oauth_error_redirects_to_sign_in_page(  # noqa
+            self,
+            MockAuthomatic,
+            MockKagisoUser,
+            mock_login,
+            mock_authenticate):
+
+        user = KagisoUser(email='test@email.com')
+        user.save = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.error = True
+
+        response = self.client.get('/oauth/facebook/', follow=True)
+
+        self.assertRedirects(response, '/sign_in/')
 
 
 class SignOutTest(TestCase):

--- a/kagiso_auth/tests/unit/test_views.py
+++ b/kagiso_auth/tests/unit/test_views.py
@@ -167,16 +167,16 @@ class SignInTest(TestCase):
     @patch('kagiso_auth.views.login', autospec=True)
     @patch('kagiso_auth.views.authenticate', autospec=True)
     def test_sign_in_valid_credentials(self, mock_authenticate, mock_login):
-        user = KagisoUser(email='test@email.com', password='password')
-        data = {'email': user.email, 'password': user.password}
-        mock_authenticate.return_value = user
+        mock_user = MagicMock()
+        data = {'email': 'test@email.com', 'password': 'secret'}
+        mock_authenticate.return_value = mock_user
 
         response = self.client.post('/sign_in/', data, follow=True)
 
         assert response.status_code == 200
         assert mock_authenticate.called
         assert mock_login.called
-        assert user.is_authenticated()
+        assert mock_user.is_authenticated()
 
 
 class OauthTest(TestCase):

--- a/kagiso_auth/utils.py
+++ b/kagiso_auth/utils.py
@@ -1,0 +1,10 @@
+from inspect import isfunction
+
+
+def get_setting(setting, request):
+    value = setting
+
+    if isfunction(value):
+        value = value(request)
+
+    return value

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -113,6 +113,7 @@ def sign_in(request):
                 user = authenticate(
                     email=email,
                     password=password,
+                    app_name=get_setting(settings.APP_NAME, request)
                 )
 
                 if user:

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -21,9 +21,10 @@ from .models import KagisoUser
 @never_cache
 @csrf_exempt
 def sign_up(request):
-    confirm_message = \
-        'You will receive an email with confirmation instructions shortly.' \
+    confirm_message = (
+        'You will receive an email with confirmation instructions shortly. '
         'This link will expire within 24 hours.'
+    )
     error_message = 'You already have an account.'
 
     if request.user.is_authenticated():
@@ -121,12 +122,14 @@ def sign_in(request):
                 else:
                     messages.error(request, 'Incorrect email or password')
             except EmailNotConfirmedError:
-                resend_str = 'Please first confirm your email address. ' \
-                    '<a href="/resend_confirmation?email={email}">' \
-                    'Resend confirmation email</a>'.format(email=email)
+                resend_message = (
+                    'Please first confirm your email address. '
+                    '<a href="/resend_confirmation?email={email}">'
+                    'Resend confirmation email</a>'
+                ).format(email=email)
                 messages.error(
                     request,
-                    mark_safe(resend_str)
+                    mark_safe(resend_message)
                 )
     else:
         form = forms.SignInForm()
@@ -300,10 +303,10 @@ def resend_confirmation(request):
 
     _send_confirmation_email(user, request)
 
-    confirm_message = \
-        'You will receive an email with confirmation instructions shortly.' \
+    confirm_message = (
+        'You will receive an email with confirmation instructions shortly. '
         'This link will expire within 24 hours.'
-
+    )
     messages.success(request, confirm_message)
 
     return HttpResponseRedirect(reverse('sign_in'))

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -168,7 +168,7 @@ def oauth(request, provider):
 
             email = result.user.data.get('email')
             provider = result.provider.name
-            user = KagisoUser.objects.filter(email=email).first()
+            user = KagisoUser.exists_in_auth_db(email)
 
             if user:
                 _social_login(request, user.email, provider)
@@ -225,7 +225,7 @@ def forgot_password(request):
 
         if form.is_valid():
             email = form.cleaned_data['email']
-            user = KagisoUser.objects.filter(email=email).first()
+            user = KagisoUser.exists_in_auth_db(email)
 
             if user:
                 msg = EmailMessage()
@@ -278,7 +278,7 @@ def reset_password(request):
                 user.reset_password(password, token)
                 messages.success(request, reset_message)
 
-                return HttpResponseRedirect('/')
+            return HttpResponseRedirect('/')
     else:
         form = forms.ResetPasswordForm(
             initial={

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -152,8 +152,11 @@ def oauth(request, provider):
 
     if result:
         if result.error:
-            print(result.error)
-            # TODO: Send back where they came from
+            messages.error(
+                request,
+                'There was an error signing you in. Please try again'
+            )
+            return HttpResponseRedirect(reverse('sign_in'))
 
         if result.user:
             # Then user is being redirected back from provider with their data

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -9,7 +9,6 @@ from django.core.urlresolvers import reverse
 from django.db.utils import IntegrityError
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
-from django.template import RequestContext
 from django.utils.safestring import mark_safe
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -17,22 +16,6 @@ from django.views.decorators.csrf import csrf_exempt
 from . import forms
 from .exceptions import EmailNotConfirmedError
 from .models import KagisoUser
-
-
-def _cas_credentials(request):
-    site_name = RequestContext(request).get('site_name')
-
-    if site_name == 'jacaranda':
-        token = settings.JAC_CAS_TOKEN
-        source_id = settings.JAC_CAS_SOURCE_ID
-    elif site_name == 'ecr':
-        token = settings.ECR_CAS_TOKEN
-        source_id = settings.ECR_CAS_SOURCE_ID
-    else:
-        token = None
-        source_id = None
-
-    return {'cas_token': token, 'cas_source_id': source_id}
 
 
 @never_cache
@@ -56,10 +39,7 @@ def sign_up(request):
 
         if form.is_valid():
             try:
-                if hasattr(request, 'site') and request.site:
-                    form.site_id = request.site.id
-
-                user = form.save(_cas_credentials(request))
+                user = form.save()
             except IntegrityError:
                 messages.error(request, error_message)
                 return HttpResponseRedirect(reverse('sign_in'))
@@ -69,7 +49,6 @@ def sign_up(request):
             if not oauth_data:
                 _send_confirmation_email(user, request)
                 messages.success(request, confirm_message)
-                # TODO: send to thank you page
                 return HttpResponseRedirect('/')
 
             _social_login(request, user.email, oauth_data['provider'])
@@ -85,17 +64,9 @@ def sign_up(request):
 
 
 def _send_confirmation_email(user, request):
-    site_name = RequestContext(request).get('site_name')
-
     msg = EmailMessage()
-
-    if site_name == 'jacaranda':
-        msg.template_name = settings.JAC_SIGN_UP_TEMPLATE
-        msg.from_email = 'noreply@jacarandafm.com'
-    elif site_name == 'ecr':
-        msg.template_name = settings.ECR_SIGN_UP_TEMPLATE
-        msg.from_email = 'noreply@ecr.co.za'
-
+    msg.template_name = settings.SIGN_UP_EMAIL_TEMPLATE
+    msg.from_email = 'noreply@kagisomedia.co.za'
     msg.subject = 'Confirm Your Account'
     msg.to = [user.email]
     msg.global_merge_vars = {
@@ -117,7 +88,6 @@ def confirm_account(request):
     token = request.GET.get('token')
 
     user = get_object_or_404(KagisoUser, id=user_id)
-    user.override_cas_credentials(_cas_credentials(request))
     user.confirm_email(token)
 
     messages.success(request, confirm_message)
@@ -127,9 +97,6 @@ def confirm_account(request):
 @never_cache
 @csrf_exempt
 def sign_in(request):
-    # TODO: Redirect to where they came from
-
-    # TODO: Move to decorator
     if request.user.is_authenticated():
         return HttpResponseRedirect('/')
 
@@ -142,12 +109,10 @@ def sign_in(request):
                 user = authenticate(
                     email=email,
                     password=password,
-                    cas_credentials=_cas_credentials(request)
                 )
 
                 if user:
                     response = HttpResponseRedirect('/')
-                    user.override_cas_credentials(_cas_credentials(request))
                     response.set_cookie('signed_in',
                                         value='true',
                                         max_age=2544)
@@ -176,9 +141,8 @@ def sign_in(request):
 @never_cache
 def oauth(request, provider):
     response = HttpResponse()
-    site_name = RequestContext(request)['site_name']
     authomatic = Authomatic(
-        settings.AUTHOMATIC_CONFIG[site_name],
+        settings.AUTHOMATIC_CONFIG,
         settings.SECRET_KEY
     )
     result = authomatic.login(DjangoAdapter(request, response), provider)
@@ -231,7 +195,6 @@ def _social_login(request, email, provider):
     user = authenticate(
         email=email,
         strategy=provider,
-        cas_credentials=_cas_credentials(request)
     )
     login(request, user)
 
@@ -239,24 +202,15 @@ def _social_login(request, email, provider):
 @never_cache
 @login_required
 def sign_out(request):
-    try:
-        request.user.override_cas_credentials(_cas_credentials(request))
-        request.user.record_sign_out()
-    finally:
-        # HACK: CMS admin users are on a different CAS account to regular
-        # JAC or ECR users, yet we don't actually care when admins sign out
-        # So just sign out regardless
-        response = HttpResponseRedirect('/')
-        response.delete_cookie('signed_in')
-        logout(request)
-        return response
+    request.user.record_sign_out()
+    response = HttpResponseRedirect('/')
+    logout(request)
+    return response
 
 
 @never_cache
 @csrf_exempt
 def forgot_password(request):
-    site_name = RequestContext(request).get('site_name')
-
     reset_message = 'You will receive an email with reset instructions shortly'
     not_found_message = 'We could not find a user for that email address'
 
@@ -268,17 +222,9 @@ def forgot_password(request):
             user = KagisoUser.objects.filter(email=email).first()
 
             if user:
-                user.override_cas_credentials(_cas_credentials(request))
-
                 msg = EmailMessage()
-
-                if site_name == 'jacaranda':
-                    msg.template_name = settings.JAC_PASSWORD_RESET_TEMPLATE
-                    msg.from_email = 'noreply@jacarandafm.com'
-                elif site_name == 'ecr':
-                    msg.template_name = settings.ECR_PASSWORD_RESET_TEMPLATE
-                    msg.from_email = 'noreply@ecr.co.za'
-
+                msg.template_name = settings.PASSWORD_RESET_EMAIL_TEMPLATE
+                msg.from_email = 'noreply@kagisomedia.co.za'
                 msg.subject = 'Password Reset'
                 msg.to = [user.email]
                 msg.global_merge_vars = {
@@ -290,6 +236,7 @@ def forgot_password(request):
                 msg.use_template_subject = True
                 msg.use_template_from = True
                 msg.send()
+
                 messages.success(request, reset_message)
                 return HttpResponseRedirect('/')
             else:
@@ -322,7 +269,6 @@ def reset_password(request):
 
             user = KagisoUser.objects.filter(id=user_id).first()
             if user:
-                user.override_cas_credentials(_cas_credentials(request))
                 user.reset_password(password, token)
                 messages.success(request, reset_message)
 

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -171,7 +171,7 @@ def oauth(request, provider):
 
             email = result.user.data.get('email')
             provider = result.provider.name
-            user = KagisoUser.exists_in_auth_db(email)
+            user = KagisoUser.get_user_from_auth_db(email)
 
             if user:
                 _social_login(request, user.email, provider)
@@ -228,7 +228,7 @@ def forgot_password(request):
 
         if form.is_valid():
             email = form.cleaned_data['email']
-            user = KagisoUser.exists_in_auth_db(email)
+            user = KagisoUser.get_user_from_auth_db(email)
 
             if user:
                 msg = EmailMessage()

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -113,10 +113,14 @@ def sign_in(request):
                 user = authenticate(
                     email=email,
                     password=password,
-                    app_name=get_setting(settings.APP_NAME, request)
                 )
 
                 if user:
+                    user.last_sign_in_via = get_setting(
+                        settings.APP_NAME,
+                        request
+                    )
+                    user.save()
                     response = HttpResponseRedirect('/')
                     response.set_cookie('signed_in',
                                         value='true',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='4.0.0',
+    version='5.0.0',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Django AuthBackend',


### PR DESCRIPTION
- Replace CAS references with 'Auth' as acronyms aren't team friendly
- Staff members dont need to confirm email addresses
- Track app from where users sign up from and where they last sign in to
- Reduce dependencies on local user existing, and treat auth api user as the canonical user
- Support settings as lambdas that take a request param

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kagiso-future-media/django_auth/35)
<!-- Reviewable:end -->
