### PR TITLE
Remember Me

### DIFF
--- a/kagiso_auth/forms.py
+++ b/kagiso_auth/forms.py
@@ -20,7 +20,7 @@ def validate_passwords_match(form):
 class SignInForm(forms.Form):
     email = forms.EmailField(label='Email Address')
     password = forms.CharField(widget=forms.PasswordInput())
-    remember_me = forms.BooleanField(required=False)
+    remember_me = forms.BooleanField(required=False, initial=True)
 
 
 class SignUpForm(forms.Form):

--- a/kagiso_auth/tests/unit/test_views.py
+++ b/kagiso_auth/tests/unit/test_views.py
@@ -235,6 +235,9 @@ class SignInTest(TestCase):
         assert mock_login.called
         assert mock_user.is_authenticated()
 
+        # To check if the expires attribute is set on the cookie, one must
+        # index the Morsel object that exists in the cookies list
+        # https://docs.python.org/3/library/http.cookies.html#morsel-objects
         for key, morsel in self.client.cookies.items():
             if key == 'sessionid':
                 assert not morsel['expires']

--- a/kagiso_auth/tests/unit/test_views.py
+++ b/kagiso_auth/tests/unit/test_views.py
@@ -217,6 +217,28 @@ class SignInTest(TestCase):
         assert mock_login.called
         assert mock_user.is_authenticated()
 
+    @patch('kagiso_auth.views.login', autospec=True)
+    @patch('kagiso_auth.views.authenticate', autospec=True)
+    def test_when_remember_me_is_unchecked_cookie_expires_attribute_is_not_set(self, mock_authenticate, mock_login):  # noqa
+        mock_user = MagicMock()
+        data = {
+            'email': 'test@email.com',
+            'password': 'secret',
+            'remember_me': False
+        }
+        mock_authenticate.return_value = mock_user
+
+        url = '/sign_in/'
+        self.client.post(url, data, follow=True)
+
+        assert mock_authenticate.called
+        assert mock_login.called
+        assert mock_user.is_authenticated()
+
+        for key, morsel in self.client.cookies.items():
+            if key == 'sessionid':
+                assert not morsel['expires']
+
 
 class OauthTest(TestCase):
 

--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -115,6 +115,7 @@ def sign_in(request):
         if form.is_valid():
             email = form.cleaned_data['email']
             password = form.cleaned_data['password']
+            remember_me = form.cleaned_data['remember_me']
             try:
                 user = authenticate(
                     email=email,
@@ -127,12 +128,12 @@ def sign_in(request):
                         request
                     )
                     user.save()
-                    response = HttpResponseRedirect(next)
-                    response.set_cookie('signed_in',
-                                        value='true',
-                                        max_age=2544)
                     login(request, user)
-                    return response
+
+                    if not remember_me:
+                        request.session.set_expiry(0)
+
+                    return HttpResponseRedirect(next)
                 else:
                     messages.error(request, 'Incorrect email or password')
             except EmailNotConfirmedError:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='6.0.0',
+    version='6.1.0',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Django AuthBackend',


### PR DESCRIPTION
#### On Sign In Form

As a user, when signing in with Remember Me **checked**, I want to be able to close my browser session and when a new browser session is started, **I'm still signed in**.

As a user, when signing in with Remember Me **unchecked**, I want to be able to close my browser session and when a new browser session is started, **I am no longer signed in**

`Remember Me` is checked by default, so the default behaviour is for the user session to persist between  browser sessions

References:
https://docs.djangoproject.com/ja/1.9/topics/http/sessions/#django.contrib.sessions.backends.base.SessionBase.set_expiry
https://docs.djangoproject.com/ja/1.9/ref/settings/#session-expire-at-browser-close
https://docs.python.org/3/library/http.cookies.html#morsel-objects
https://pymotw.com/2/Cookie/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagiso-future-media/django_auth/43)
<!-- Reviewable:end -->
