### PR TITLE
Oauth Fix

### DIFF
--- a/kagiso_auth/views.py
+++ b/kagiso_auth/views.py
@@ -182,9 +182,8 @@ def oauth(request, provider):
             if not (result.user.name and result.user.id):
                 result.user.update()
 
-            email = result.user.data.get('email')
             provider = result.provider.name
-            user = KagisoUser.get_user_from_auth_db(email)
+            user = KagisoUser.get_user_from_auth_db(result.user.email)
 
             if user:
                 _social_login(request, user.email, provider)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_django_auth',
-    version='8.0.0',
+    version='8.0.1',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Django AuthBackend',


### PR DESCRIPTION
When trying to login with Google, I used an email address that does exist in `auth.kagiso.io`, but after returning from Google, I was shown the Registration screen.

I found the email variable was `None`, thats because there is no email in the `request.user.data` dict, instead it looks as following.

```
{'circledByCount': 10, 'displayName': 'Colin Frank Bob', 'language': 'en', 'url': 'https://plus.google.com/105784672166258151193', 'name': {'givenName': 'Colin Frank', 'familyName': 'Bob'}, 'verified': False, 'etag': '"4OZ_Kt6ujOh1jaML_U6RM6APqoE/c2o4umGByGUf3E5czqpJPPnFpFI"', 'gender': 'male', 'objectType': 'person', 'image': {'isDefault': True, 'url': 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg?sz=50'}, 'id': '105784672166258151193', 'kind': 'plus#person', 'emails': [{'value': 'colinfrankb@gmail.com', 'type': 'account'}], 'isPlusUser': True}

```

only `emails`

using `request.user.email` returns the correct value.

Retested with Facebook logins, works fine!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagiso-future-media/django_auth/46)
<!-- Reviewable:end -->
